### PR TITLE
Fix generation of VAR parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ build:
 fractions: build
 	java -cp $(OBERON_BIN):out OSP examples/Fractions.Mod
 
+incr: build
+	java -cp $(OBERON_BIN):out OSP examples/Incr.Mod
+
 magicSquares: build
 	java -cp $(OBERON_BIN):out OSP examples/MagicSquares.Mod
 

--- a/examples/Incr.Mod
+++ b/examples/Incr.Mod
@@ -1,0 +1,18 @@
+MODULE Incr;
+
+PROCEDURE Inc(a :INTEGER; VAR x :INTEGER);
+BEGIN
+  x := a + x
+END Inc;
+
+PROCEDURE Go;
+VAR i :INTEGER;
+BEGIN
+  i := 5;
+  Inc(1, i);
+  WriteInt(i);
+  WriteLn
+END Go;
+
+BEGIN Go
+END Incr.

--- a/src/OSG.Mod
+++ b/src/OSG.Mod
@@ -171,7 +171,13 @@ MODULE OSG; (* NW 19.12.94 / 20.10.07 / 26.10.2013*)
 
   PROCEDURE MakeItem*(VAR x: Item; y: Object; curlev: LONGINT);
   BEGIN x.mode := y.class; x.type := y.type; x.a := y.val; x.r := y.lev;
+(* Bug fix:
+   NW's original code here was
     IF y.class = Par THEN x.b := 0 END ;
+   For a VAR parameter, this leaves x.r undefined. Since this is a Par,
+   the source of the register should always be SP.
+*)
+    IF y.class = Par THEN x.r := SP; x.b := 0 END ;
     IF (y.lev > 0) & (y.lev # curlev) & (y.class # Const) THEN OSS.Mark("level error") END
   END MakeItem;
 


### PR DESCRIPTION
Before this fix, the incr example crashed:

  Oberon-0 Compiler OSP  30.10.2013
    compiling Incr
  code generated    32     0
  Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 8193 out of bounds for length 8192
          at RISC.Execute(RISC.Mod:47)
          at OSG.Execute(OSG.Mod:460)
          at OSP.Main(OSP.Mod:470)
          at OSP.main(OSP.Mod)
  make: *** [Makefile:14: incr] Error 1

The reason for this is that VAR parameter generation in Oberon-0 was
broken. For a parameter, the register referred to by the parameter was
undefined, and would default to whatever happened to be in the item
previously, which was always wrong.

The generated RISC code changes from:

   580E00004	LDW R0 SP       4   ; load a
   681100008	LDW R1 R1       8   ; R1 is unset!
   781100000	LDW R1 R1       0   ; Crash
   800080001	ADD R0 R0 R1

To:

   580E00004	LDW R0 SP       4   ; load a
   681E00008	LDW R1 SP       8   ; load adr(x)
   781100000	LDW R1 R1       0   ; load x
   800080001	ADD R0 R0 R1        ; a + x
   981E00008	LDW R1 SP       8   ; adr(x)
  10A0100000	STW  R0 R1       0  ; store a + x